### PR TITLE
로그인 구현

### DIFF
--- a/pofolduce201/src/main/java/org/kosa/_musketeers/controller/UserController.java
+++ b/pofolduce201/src/main/java/org/kosa/_musketeers/controller/UserController.java
@@ -5,10 +5,10 @@ import org.kosa._musketeers.service.UserService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Controller;
-import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
@@ -30,20 +30,20 @@ public class UserController {
 	}
 	
 	@PostMapping("/login/processing")
-	public String loginProcessing(@RequestParam String email, @RequestParam String password, HttpServletRequest request, Model model) {
+	public String loginProcessing(@RequestParam String email, @RequestParam String password, HttpServletRequest request,  RedirectAttributes redirectAttributes) {
 		
 		logger.info("email:" + email + " password" + password);
 		User user = userService.login(email, password);
-		String redirectURL = "pages/login/login";
+		String page = "redirect:/login";
 		if(user != null) {
 			HttpSession httpSession = request.getSession();
 			httpSession.setAttribute("userId", user.getUserId());
-			redirectURL = "redirect:/home";
+			page = "redirect:/home";
 		}else {
-			model.addAttribute("loginFailMessage", "아이디 or 비밀번호가 잘못입력되었습니다");
+			redirectAttributes.addFlashAttribute("loginFailMessage", "아이디 or 비밀번호가 잘못입력되었습니다");
 		}
 		
-		return redirectURL;
+		return page;
 	}
 	
 	@GetMapping("/home")

--- a/pofolduce201/src/main/java/org/kosa/_musketeers/controller/UserController.java
+++ b/pofolduce201/src/main/java/org/kosa/_musketeers/controller/UserController.java
@@ -1,0 +1,53 @@
+package org.kosa._musketeers.controller;
+
+import org.kosa._musketeers.domain.User;
+import org.kosa._musketeers.service.UserService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+
+@Controller
+public class UserController {
+	
+	UserService userService;
+	
+	Logger logger = LoggerFactory.getLogger(this.getClass());
+	
+	public UserController(UserService userService){
+		this.userService = userService;
+	}
+	
+	@GetMapping("/login")
+	public String login() {
+		return "pages/login/login";
+	}
+	
+	@PostMapping("/login/processing")
+	public String loginProcessing(@RequestParam String email, @RequestParam String password, HttpServletRequest request, Model model) {
+		
+		logger.info("email:" + email + " password" + password);
+		User user = userService.login(email, password);
+		String redirectURL = "pages/login/login";
+		if(user != null) {
+			HttpSession httpSession = request.getSession();
+			httpSession.setAttribute("userId", user.getUserId());
+			redirectURL = "redirect:/home";
+		}else {
+			model.addAttribute("loginFailMessage", "아이디 or 비밀번호가 잘못입력되었습니다");
+		}
+		
+		return redirectURL;
+	}
+	
+	@GetMapping("/home")
+	public String home() {
+		return "index";
+	}
+}

--- a/pofolduce201/src/main/java/org/kosa/_musketeers/mapper/UserMapper.java
+++ b/pofolduce201/src/main/java/org/kosa/_musketeers/mapper/UserMapper.java
@@ -1,0 +1,11 @@
+package org.kosa._musketeers.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.kosa._musketeers.domain.User;
+
+@Mapper
+public interface UserMapper {
+
+	User getUserIdByEmailPwd(@Param("email") String email, @Param("password") String password);
+}

--- a/pofolduce201/src/main/java/org/kosa/_musketeers/service/UserService.java
+++ b/pofolduce201/src/main/java/org/kosa/_musketeers/service/UserService.java
@@ -1,0 +1,19 @@
+package org.kosa._musketeers.service;
+
+import org.kosa._musketeers.domain.User;
+import org.kosa._musketeers.mapper.UserMapper;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserService {
+
+	private UserMapper userMapper;
+
+	UserService(UserMapper userMapper) {
+		this.userMapper = userMapper;
+	}
+
+	public User login(String email, String password) {
+		return userMapper.getUserIdByEmailPwd(email, password);
+	}
+}

--- a/pofolduce201/src/main/resources/org/kosa/_musketeers/mapper/UserMapper.xml
+++ b/pofolduce201/src/main/resources/org/kosa/_musketeers/mapper/UserMapper.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="org.kosa._musketeers.mapper.UserMapper">
+	<select id="getUserIdByEmailPwd" parameterType="map" resultType="org.kosa._musketeers.domain.User">
+		SELECT user_id
+		FROM users
+		WHERE email=#{email} and password=#{password}
+	</select>
+</mapper>

--- a/pofolduce201/src/main/resources/templates/index.html
+++ b/pofolduce201/src/main/resources/templates/index.html
@@ -18,7 +18,7 @@
 <div th:replace="fragments/html/header1 :: header1"></div>
 <div th:replace="fragments/html/header2 :: header2"></div>
 <div th:replace="fragments/html/header3 :: header3('/')"></div>
-<div th:replace="fragments/html/board-header :: board-header"></div>
+<div th:replace="fragments/html/board-header :: board-header('메인페이지')"></div>
 <div th:replace="fragments/html/banner :: banner('이력서 및 자기소개서, 포트폴리오를 첨삭받을 수 있는 게시판 입니다.', '관련 없는 게시글 및 광고성 정보, 욕설이 포함된 게시글은 예고 없이 삭제될 수 있습니다.','첨삭 시 반드시 매너를 지켜주세요!')"></div>
 <div th:replace="fragments/html/footer :: footer"></div>
 

--- a/pofolduce201/src/main/resources/templates/pages/login/login.html
+++ b/pofolduce201/src/main/resources/templates/pages/login/login.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+	xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+	layout:decorate="~{layouts/layout}">
+<head>
+<title>main1</title>
+</head>
+<!--/* 
+		body tag 는 명시하지 않는다  layout.html 의 content fragment 영역에 삽입될 부분이기 때문 
+ */-->
+<div layout:fragment="content">
+	<div>
+		<form action="/login/processing" method="post">
+			<input type="text" name="email"><br> <input type="password"
+				name="password"><br>
+			<button type="button" id="register">회원가입</button>
+			<button type="submit">로그인</button>
+		</form>
+	</div>
+	<div th:if="${loginFailMessage}" th:inline="javascript">
+		<script>
+        alert([[${loginFailMessage}]]);
+		</script>
+	</div>
+</div>
+</html>

--- a/pofolduce201/src/test/java/org/kosa/_musketeers/login/LoginTest.java
+++ b/pofolduce201/src/test/java/org/kosa/_musketeers/login/LoginTest.java
@@ -2,10 +2,13 @@ package org.kosa._musketeers.login;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
 
 import org.junit.jupiter.api.Test;
+import org.kosa._musketeers.domain.User;
 import org.kosa._musketeers.mapper.UserMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -24,13 +27,36 @@ public class LoginTest {
 	private UserMapper mapper;
 	
 	@Test
-	public void loginTest() throws Exception {
+	public void loginSuccessTest() throws Exception {
 		
+		//given
+		String email = "user1@example.com";
+		String password = "pass1234";
+		
+		//when
 		mockMvc.perform(post("/login/processing")
-				.param("email", "email")
-				.param("password", "1234")
+				.param("email", email)
+				.param("password", password)
+				
+		//then
 		).andExpect(status().isFound())
 		.andExpect(redirectedUrl("/home"));
+	}
+	
+	@Test
+	public void loginFailTest() throws Exception {
+		String email = "wrongemail";
+		String password = "pass1234";
+		
+		//when
+		mockMvc.perform(post("/login/processing")
+				.param("email", email)
+				.param("password", password)
+				
+		//then
+		).andExpect(status().isOk())
+        .andExpect(view().name("pages/login/login"))
+        .andExpect(model().attributeExists("loginFailMessage"));
 	}
 	
 	@Test
@@ -41,10 +67,11 @@ public class LoginTest {
 		String password = "pass1234";
 		
 		//when
-		int id = mapper.getUserIdByEmailPwd(email, password);
+		User user = mapper.getUserIdByEmailPwd(email, password);
 		
 		//then
-		assertThat(id).isEqualTo(1);
+		assertThat(user).isNotNull();
+		assertThat(user.getUserId()).isEqualTo(1);
 	}
 
 }

--- a/pofolduce201/src/test/java/org/kosa/_musketeers/login/LoginTest.java
+++ b/pofolduce201/src/test/java/org/kosa/_musketeers/login/LoginTest.java
@@ -1,0 +1,50 @@
+package org.kosa._musketeers.login;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.kosa._musketeers.mapper.UserMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+public class LoginTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+	@Autowired
+	private UserMapper mapper;
+	
+	@Test
+	public void loginTest() throws Exception {
+		
+		mockMvc.perform(post("/login/processing")
+				.param("email", "email")
+				.param("password", "1234")
+		).andExpect(status().isFound())
+		.andExpect(redirectedUrl("/home"));
+	}
+	
+	@Test
+	public void getUserIdByEmailPwdTest() {
+		
+		//given
+		String email = "user1@example.com";
+		String password = "pass1234";
+		
+		//when
+		int id = mapper.getUserIdByEmailPwd(email, password);
+		
+		//then
+		assertThat(id).isEqualTo(1);
+	}
+
+}


### PR DESCRIPTION
# 📑 PR 요약

사이트의 기본적인 기능인 로그인을 구현하였습니다.
## 🔗 관련 이슈

<!-- 관련있는 이슈 번호(#000)을 적어주세요. 해당 pull request merge와 함께 이슈를 닫으려면 closed #이슈 번호를 적어주세요 -->
#17 
closed #17 
## ☑ 작업 내용
기본적인 로그인페이지를 만들고 controller, service, mapper에 메서드를 작성하여, 이메일과 비밀번호를 사용하여 해당 user를 찾을 수 있도록 하였습니다. 찾은 뒤 session에 유저 id를 저장하도록 했습니다. 이후 홈페이지로 리다이렉트합니다.
실패한다면 저장하지 않고 로그인페이지로 리다이렉트 한 뒤, 경고창을 띄웁니다.

- UserController login() 
- UserService login9)
- UserMapper findUserByEmailPwd() 작성

## 단위 테스트 결과
단위테스트 loginSucessTest, loginFailTest 모두 통과.

- 사진 첨부

## ✅ 기타 사항
